### PR TITLE
Replace ganache with anvil using ur address from base chain

### DIFF
--- a/integration_tests/buy_v2_v3_base.py
+++ b/integration_tests/buy_v2_v3_base.py
@@ -2,7 +2,6 @@ import os
 import subprocess
 import time
 
-from eth_utils import keccak
 from web3 import (
     Account,
     Web3,
@@ -17,13 +16,13 @@ from uniswap_universal_router_decoder import (
 
 web3_provider = os.environ['WEB3_HTTP_PROVIDER_URL_BASE_MAINNET']
 w3 = Web3(Web3.HTTPProvider("http://127.0.0.1:8545"))
-chain_id = 1337
-block_number = 12668306
+chain_id = 8453
+block_number = 36307425  # More recent Base block
 gas_limit = 800_000
 
-account = Account.from_key(keccak(text="moo"))
-assert account.address == "0xcd7328a5D376D5530f054EAF0B9D235a4Fd36059"
-init_amount = 100 * 10**18
+account = Account.from_key("0xf7e96bcf6b5223c240ec308d8374ff01a753b00743b3a0127791f37f00c56514")
+assert account.address == "0x1e46c294f20bC7C27D93a9b5f45039751D8BCc3e"
+init_amount = 10000 * 10**18
 
 erc20_abi = '[{"constant":true,"inputs":[],"name":"name","outputs":[{"name":"","type":"string"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":false,"inputs":[{"name":"_spender","type":"address"},{"name":"_value","type":"uint256"}],"name":"approve","outputs":[{"name":"","type":"bool"}],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":true,"inputs":[],"name":"totalSupply","outputs":[{"name":"","type":"uint256"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":false,"inputs":[{"name":"_from","type":"address"},{"name":"_to","type":"address"},{"name":"_value","type":"uint256"}],"name":"transferFrom","outputs":[{"name":"","type":"bool"}],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":true,"inputs":[],"name":"decimals","outputs":[{"name":"","type":"uint8"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":true,"inputs":[{"name":"_owner","type":"address"}],"name":"balanceOf","outputs":[{"name":"","type":"uint256"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":true,"inputs":[],"name":"symbol","outputs":[{"name":"","type":"string"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":false,"inputs":[{"name":"_to","type":"address"},{"name":"_value","type":"uint256"}],"name":"transfer","outputs":[{"name":"","type":"bool"}],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":true,"inputs":[{"name":"_owner","type":"address"},{"name":"_spender","type":"address"}],"name":"allowance","outputs":[{"name":"","type":"uint256"}],"payable":false,"stateMutability":"view","type":"function"},{"anonymous":false,"inputs":[{"indexed":true,"name":"_from","type":"address"},{"indexed":true,"name":"_to","type":"address"},{"indexed":false,"name":"_value","type":"uint256"}],"name":"Transfer","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"name":"_owner","type":"address"},{"indexed":true,"name":"_spender","type":"address"},{"indexed":false,"name":"_value","type":"uint256"}],"name":"Approval","type":"event"}]'  # noqa
 weth_abi = '[{"constant":true,"inputs":[],"name":"name","outputs":[{"name":"","type":"string"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":false,"inputs":[{"name":"guy","type":"address"},{"name":"wad","type":"uint256"}],"name":"approve","outputs":[{"name":"","type":"bool"}],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":true,"inputs":[],"name":"totalSupply","outputs":[{"name":"","type":"uint256"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":false,"inputs":[{"name":"src","type":"address"},{"name":"dst","type":"address"},{"name":"wad","type":"uint256"}],"name":"transferFrom","outputs":[{"name":"","type":"bool"}],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":false,"inputs":[{"name":"wad","type":"uint256"}],"name":"withdraw","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":true,"inputs":[],"name":"decimals","outputs":[{"name":"","type":"uint8"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":true,"inputs":[{"name":"","type":"address"}],"name":"balanceOf","outputs":[{"name":"","type":"uint256"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":true,"inputs":[],"name":"symbol","outputs":[{"name":"","type":"string"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":false,"inputs":[{"name":"dst","type":"address"},{"name":"wad","type":"uint256"}],"name":"transfer","outputs":[{"name":"","type":"bool"}],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":false,"inputs":[],"name":"deposit","outputs":[],"payable":true,"stateMutability":"payable","type":"function"},{"constant":true,"inputs":[{"name":"","type":"address"},{"name":"","type":"address"}],"name":"allowance","outputs":[{"name":"","type":"uint256"}],"payable":false,"stateMutability":"view","type":"function"},{"payable":true,"stateMutability":"payable","type":"fallback"},{"anonymous":false,"inputs":[{"indexed":true,"name":"src","type":"address"},{"indexed":true,"name":"guy","type":"address"},{"indexed":false,"name":"wad","type":"uint256"}],"name":"Approval","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"name":"src","type":"address"},{"indexed":true,"name":"dst","type":"address"},{"indexed":false,"name":"wad","type":"uint256"}],"name":"Transfer","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"name":"dst","type":"address"},{"indexed":false,"name":"wad","type":"uint256"}],"name":"Deposit","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"name":"src","type":"address"},{"indexed":false,"name":"wad","type":"uint256"}],"name":"Withdrawal","type":"event"}]'  # noqa
@@ -32,23 +31,25 @@ weth_address = Web3.to_checksum_address("0x4200000000000000000000000000000000000
 usdc_address = Web3.to_checksum_address("0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913")
 usdc_contract = w3.eth.contract(address=usdc_address, abi=erc20_abi)  # 6 decimals
 
-ur_address = Web3.to_checksum_address("0x3fC91A3afd70395Cd496C647d5a6CC9D4B2b7FAD")
+ur_address = Web3.to_checksum_address("0x6ff5693b99212da76ad316178a184ab56d299b43")
 
 codec = RouterCodec()
 
 
-def launch_ganache():
-    ganache_process = subprocess.Popen(
-        f"""ganache
-        --logging.quiet='true'
-        --fork.url='{web3_provider}'
-        --fork.blockNumber='{12668306}'
-        --wallet.accounts='{account.key.hex()}','{init_amount}'
-        """.replace("\n", " "),
+def launch_anvil():
+    anvil_process = subprocess.Popen(
+        " ".join(
+            [
+                "anvil -vvvvv",
+                f"--fork-url {web3_provider}",
+                f"--fork-block-number {block_number}",
+                "--mnemonic-seed-unsafe 8721345628937456298",
+            ]
+        ),
         shell=True,
     )
-    time.sleep(3)
-    parent_id = ganache_process.pid
+    time.sleep(2)
+    parent_id = anvil_process.pid
     return parent_id
 
 
@@ -63,8 +64,8 @@ def kill_processes(parent_id):
 
 
 def check_initialization():
-    assert w3.eth.chain_id == chain_id  # 1337
-    assert w3.eth.block_number == block_number + 1
+    assert w3.eth.chain_id == chain_id  # 8453
+    assert w3.eth.block_number == block_number
     assert w3.eth.get_balance(account.address) == init_amount
     assert usdc_contract.functions.balanceOf(account.address).call() == 0
     print(" => Initialization: OK")
@@ -83,7 +84,7 @@ def send_transaction(value, encoded_data):
         "nonce": w3.eth.get_transaction_count(account.address),
         "data": encoded_data,
     }
-    raw_transaction = w3.eth.account.sign_transaction(trx_params, account.key).rawTransaction
+    raw_transaction = w3.eth.account.sign_transaction(trx_params, account.key).raw_transaction
     trx_hash = w3.eth.send_raw_transaction(raw_transaction)
     return trx_hash
 
@@ -112,8 +113,9 @@ def buy_usdc_from_v2_and_v3():
     assert receipt["status"] == 1  # trx success
     assert w3.eth.get_balance(account.address) < init_amount - total_in_amount
     bought_usdc = usdc_contract.functions.balanceOf(account.address).call()
-    print(bought_usdc)
-    assert bought_usdc == 6577482677
+    print(f"Bought USDC: {bought_usdc}")
+    # Allow for some variation due to market conditions, but should be approximately 8.7-8.8k USDC
+    assert 8_700_000_000 <= bought_usdc <= 8_800_000_000, f"Bought USDC amount {bought_usdc} is outside expected range"
 
     print(" => BUY USDC: OK")
 
@@ -133,12 +135,12 @@ def print_success_message():
 
 
 def main():
-    ganache_pid = launch_ganache()
+    anvil_pid = launch_anvil()
     try:
         launch_integration_tests()
         print_success_message()
     finally:
-        kill_processes(ganache_pid)
+        kill_processes(anvil_pid)
 
 
 if __name__ == "__main__":

--- a/integration_tests/buy_v2_v3_base.py
+++ b/integration_tests/buy_v2_v3_base.py
@@ -114,8 +114,7 @@ def buy_usdc_from_v2_and_v3():
     assert w3.eth.get_balance(account.address) < init_amount - total_in_amount
     bought_usdc = usdc_contract.functions.balanceOf(account.address).call()
     print(f"Bought USDC: {bought_usdc}")
-    # Allow for some variation due to market conditions, but should be approximately 8.7-8.8k USDC
-    assert 8_700_000_000 <= bought_usdc <= 8_800_000_000, f"Bought USDC amount {bought_usdc} is outside expected range"
+    assert bought_usdc == 8743089218, f"Expected exactly 8743089218 USDC, but got {bought_usdc}"
 
     print(" => BUY USDC: OK")
 


### PR DESCRIPTION
## Testing Infrastructure
- Replace `launch_ganache()` with `launch_anvil()`.
- Update `subprocess` to use Foundry’s anvil with proper fork parameters.
- Follow same pattern as existing anvil tests (`v2_v3_swap.py`, `v4.py`).

## Universal Router Upgrade
- Update contract from `0x3fC91A3afd70395Cd496C647d5a6CC9D4B2b7FAD` → `0x6ff5693b99212da76ad316178a184ab56d299b43`.
- Now uses UniversalRouterV2 (latest version) on Base chain.

## Base Chain Configuration
- Chain ID: `1337` → `8453` (Base mainnet).
- Block number updated to recent Base block `36307425`.
- Verified token addresses remain current (WETH, USDC).
